### PR TITLE
Alterando nome do projeto no gradle para corresponder com o nome do repo

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'api-sea'
+rootProject.name = 'sea-api'


### PR DESCRIPTION
A configuração foi alterada para que o nome do projeto nas configurações do gradle corresponda ao nome do repositório.

closes #5 